### PR TITLE
2020-08-11 RecvBuffer 추가 내용

### DIFF
--- a/Server_proj/RecvBuffer.cs
+++ b/Server_proj/RecvBuffer.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Server_Core
+{
+    public class RecvBuffer
+    {
+        //[][][r][][w][][][][][]
+        ArraySegment<byte> _buffer;
+
+        int _readPos; // 처리해야할 데이터 유효 범위  (_writePos - _readPos)
+        int _writePos; //몇 바이트까지 받았는지, 다음에 받아야할 위치
+
+        public RecvBuffer(int buffserSize)
+        {
+            _buffer = new ArraySegment<byte>(new byte[buffserSize], 0, buffserSize);
+        }
+
+        //버퍼에 받은 데이터 범위
+        public int DataSize { get { return _writePos - _readPos; } }
+
+        //버퍼에 남은 유효 범위
+        public int FreeSize { get { return _buffer.Count - _writePos; } }
+        
+        // DataSegment (받은 데이터 범위 크기의 ArraySegment<byte>를 반환
+        // 어디서 부터(_readPos) ~ 어디 까지(DataSize) 읽어야 되는지
+        public ArraySegment<byte> DataSegment { get { return new ArraySegment<byte>(_buffer.Array, _buffer.Offset+_readPos, DataSize); } }
+
+
+        // 사용할 수 있는 버퍼의 유효 범위 RecvSegment 
+        // 다음 Receive에서 어디서 부터(_writePos) ~ 어디까지가 유효범위인지  (FreeSize)
+        public ArraySegment<byte> FreeSegment { get { return new ArraySegment<byte>(_buffer.Array, _buffer.Offset+_writePos, FreeSize); } }
+
+
+        // Clean()r , w 가 버퍼 끝까지 밀릴 수 있으므로 r,w Pos를 당겨주는 역할
+
+        public void Clean()
+        {
+            int datasize = DataSize;
+            
+            if(datasize == 0) //[rw] 겹쳐 있는 상황 모든 데이터를 이상없이 처리한 상태
+            {
+                //남은 데이터가 없으면 복사하지 않고 커서를 원위치(0)로
+                _readPos = _writePos = 0;
+            }
+            else //클라이언트로 부터 데이터를 일부만 받은 상태.
+            {
+
+                Array.Copy(_buffer.Array, _buffer.Offset + _readPos, 
+                           _buffer.Array, _buffer.Offset, DataSize);
+
+                _readPos = 0;
+                _writePos = DataSize;
+            }
+        }
+
+        //_readPos , _writePos 커서 이동
+        public bool OnRead(int transferredSize)
+        {
+            if (transferredSize > DataSize)
+                return false;
+
+            _readPos += transferredSize;
+            return true;
+        }
+        public bool OnWrite(int transferredSize)
+        {
+            if (transferredSize > FreeSize)
+                return false;
+
+            _writePos += transferredSize;
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
기존 Server 또는 Client에서 Session을 만들때
Receive 버퍼를 SocketAsyncEventArgs 에서 SetBuffer로
고정된 크기로 크기 전체를 오프셋 0부터 만들어서 OnReceive로 전달하였다.

하지만 이 과정에서는, TCP에서 데이터가 완벽히 전송되거나 아얘 전송되지
않거나를 기준으로 데이터를 버퍼에 담았다.

TCP 통신에서 데이터를 수신측에서 일부만 받게되는 경우를 고려하여
RecvBuffer.cs 클래스를 새로 만들어 주었다.

만약 100byte를 전송해야하는데 80byte만 전송된 경우
버퍼에 받은 데이터 범위와, 버퍼에 남은 유효 범위를 고려하여
Segment 버퍼를 이용하였음, 정의된 프로퍼티,인터페이스는 주석 내용 참고.